### PR TITLE
fix: dont invent edges when clipping solid blocks

### DIFF
--- a/organelle_morphology/source.py
+++ b/organelle_morphology/source.py
@@ -755,7 +755,7 @@ class DataSource:
 
         if overlap:
             d_data = da.overlap.overlap(
-                self.data, depth={0: 2, 1: 2, 2: 2}, boundary={0: 0, 1: 0, 2: 0}
+                self.data, depth={0: 2, 1: 2, 2: 2}, boundary="reflect"
             ).to_delayed()
         else:
             d_data = self.data.to_delayed()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -49,6 +49,20 @@ def test_block_mesher_c_on_edge(voxels_c_on_edge):
     assert len(ids) == 1
 
 
+def test_block_mesher_solid():
+    voxels = np.ones((10, 10, 10))
+    meshes, ids = compute(
+        *source._block_mesher(
+            block=voxels,
+            space_offset=(0, 0, 0),
+            debug_color=0,
+        ),
+        scheduler="single-threaded",
+    )
+    assert len(meshes) == 0
+    assert len(ids) == 0
+
+
 def plot_voxels(voxels):
     """For debugging"""
     cm = mpl.colormaps["tab20"]


### PR DESCRIPTION
At borders, voxel data will be reflected instead of zero-padded during the splitting in chunks. The reflected zone is cut away during meshing.