### PR TITLE
tests: fix synthetic data fixture

### DIFF
--- a/organelle_morphology/util.py
+++ b/organelle_morphology/util.py
@@ -15,6 +15,7 @@ import time
 import numpy as np
 
 
+logger = logging.getLogger(__name__)
 CACHE_DIR = xdg.xdg_cache_home() / "organelle_morphology"
 
 
@@ -52,11 +53,14 @@ class Disk_Store:
     def clear(self):
         for f in self.path.iterdir():
             f.unlink()
-        self.path.rmdir()
+        if self.path.exists():
+            logger.debug(f"Removing cachedir: {self.path}")
+            self.path.rmdir()
         for dir in self.path.parents:
             if dir == self.cache_root:
                 break
             try:
+                logger.debug(f"Trying to remove cacheparent: {dir}")
                 dir.rmdir()
             except OSError:
                 break
@@ -97,12 +101,14 @@ class Cache:
             store[key] = value
 
     def __getitem__(self, key):
+        error = None
         for store in self.stores:
             try:
                 return store[key]
-            except KeyError:
+            except KeyError as e:
+                error = e
                 pass
-        raise KeyError(f"Key {key} not in cache!")
+        raise KeyError(f"Key {key} not in cache! {error}")
 
     def __contains__(self, key):
         for store in self.stores:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,9 @@ def synthetic_data(_synthetic_data, tmp_path: Path):
     """
     project_path, original_meshes = _synthetic_data
     new_project = tmp_path / project_path.name
-    new_project.symlink_to(project_path)
+    new_project.mkdir()
+    for item in project_path.iterdir():
+        (new_project / item.name).symlink_to(item)
 
     return (new_project, original_meshes)
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -277,6 +277,8 @@ def test_mcs_dicts(project_with_sources):
     p = project_with_sources
     s = list(project_with_sources.sources.values())[0]
 
+    if len(ps := list(p.path.glob("cache*"))):
+        raise RuntimeError(f"Existing caches found!!\n{ps}")
     p.search_mcs(10)
     mcs_dicts = s.mcs_dicts
     assert list(mcs_dicts.keys()) == ["0.0-10,-"]


### PR DESCRIPTION
The synthetic data fixture now provides a proper temp dir containing symlinks to the data, instead of symlinking to the whole *directory* containing the data, leading to shared caches in test runs