### PR TITLE
fix: domain decomposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,26 @@ on:
 jobs:
   build-and-test:
     name: Testing on ${{matrix.os}} (Python ${{matrix.python-version}})
-    if: github.event.pull_request.draft == false|| github.event_name != 'pull_request'
+    if: "!contains(github.event.pull_request.draft, 'true')"
     runs-on: ${{matrix.os}}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.13"]
     defaults:
       run:
-        shell: bash -l {0}
+        shell: ${{ matrix.os == 'windows' && 'powershell' || 'bash -el {0}' }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
         with:
           # setuptools_scm requires a non-shallow clone of the repository
           fetch-depth: 0
 
       - name: Add conda instance
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4.0.0
         with:
           miniforge-version: latest
           mamba-version: "*"
@@ -46,50 +47,13 @@ jobs:
           environment-file: environment-dev.yml
           conda-remove-defaults: true
 
-      - name: Install Python package
-        run: |
-          python -m pip install --no-deps .
-
       - name: Run Python tests
         run: |
-          python -m pytest
+          pytest --cov --cov-report=xml
 
-  coverage:
-    name: Coverage Testing
-    if: github.event.pull_request.draft == false|| github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Add conda instance
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniforge-version: latest
-          mamba-version: "*"
-          channels: local,conda-forge
-          python-version: 3.11
-          activate-environment: morph
-          environment-file: environment-dev.yml
-          conda-remove-defaults: true
-
-      - name: Install Python package
-        run: |
-          python -m pip install .[tests]
-
-      - name: Run Python tests
-        working-directory: ./tests
-        run: |
-          python -m pytest --cov --cov-report=xml
-
-      - name: Upload coverage to Codecov
+      - name: Upload coverage reports to Codecov
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: true
-          files: ./tests/coverage.xml
-        env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.13"]
+        # os: [ubuntu-latest, windows-latest]
+        # python-version: ["3.11", "3.13"]
+        os: [windows-latest]
+        python-version: ["3.11"]
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'powershell' || 'bash -el {0}' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,21 @@ on:
 jobs:
   build-and-test:
     name: Testing on ${{matrix.os}} (Python ${{matrix.python-version}})
-    if: "!contains(github.event.pull_request.draft, 'true')"
     runs-on: ${{matrix.os}}
     timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.13"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.11"
+    if: ${{ github.event.pull_request == null || github.event.pull_request.draft != true }}
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'powershell' || 'bash -el {0}' }}
 
     steps:
-      - name: Skip broken combination of py311 and windows
-        if: always() && matrix.os == 'windows-latest' && matrix.python-version == '3.11'
-        run: exit 0
-
       - name: Checkout repository
         uses: actions/checkout@v6.0.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ["3.11", "3.13"]
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows' && 'powershell' || 'bash -el {0}' }}
+        shell: ${{ matrix.os == 'windows-latest' && 'powershell' || 'bash -el {0}' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,13 @@
 name: CI
 
 on:
-  # We run CI on pushes to the main branch
   push:
     branches:
       - main
-      - om2
-  # and on all pull requests to the main branch
   pull_request:
     branches:
       - main
-      - om2
     types: [opened, synchronize, reopened, ready_for_review]
-  # as well as upon manual triggers through the 'Actions' tab of the Github UI
   workflow_dispatch:
 
 jobs:
@@ -23,15 +18,17 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest]
-        # python-version: ["3.11", "3.13"]
-        os: [windows-latest]
-        python-version: ["3.11"]
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.13"]
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'powershell' || 'bash -el {0}' }}
 
     steps:
+      - name: Skip broken combination of py311 and windows
+        if: always() && matrix.os == 'windows-latest' && matrix.python-version == '3.11'
+        run: exit 0
+
       - name: Checkout repository
         uses: actions/checkout@v6.0.3
         with:
@@ -55,7 +52,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: always() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7.0.0
         with:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/notebooks/ui.py
+++ b/notebooks/ui.py
@@ -567,7 +567,12 @@ def _(box_dict, mesh_id_filter, project):
 
     box_dict  # control flow
     mesh_id_filter  # control flow
-    mo.ui.button(on_click=ids_in_box, label="Get IDs of organelles in box", value=None)
+    get_ids_box_ui = mo.ui.button(on_click=ids_in_box, label="Get IDs", value=None)
+    mo.md(
+        "<h3>Show IDs of Organelles in the box.</h3>"
+        "Change the box in the `Show mesh` panel.<br>"
+        f"{get_ids_box_ui}"
+    )
     return
 
 

--- a/notebooks/ui.py
+++ b/notebooks/ui.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.5"
 app = marimo.App(
     width="medium",
     app_title="Organelle Morphology",

--- a/organelle_morphology/distance_calculations.py
+++ b/organelle_morphology/distance_calculations.py
@@ -284,7 +284,7 @@ def generate_distance_matrix(
         project.logger.info("Initializing distance matrix")
 
         organelles = np.array(project.organelles)
-        organelles_ids = np.array(project.organelle_ids)
+        organelles_ids = np.array([o.id for o in organelles])
         meshes = []
         bounding_boxes = []
         for organelle in organelles:
@@ -308,7 +308,6 @@ def generate_distance_matrix(
             columns=organelles_ids,
         )
 
-        # TODO: Better use data chunks instead of our own boxes
         if domain_decomposition:
             # domain decomposition into chunks of
             # size = size of clipped data in units of the resolution
@@ -355,7 +354,7 @@ def generate_distance_matrix(
                 box = (start, end)
                 tasks.append((box, bounding_boxes))
             # masks = list(map(lambda b: _check_overlap(b, bounding_boxes), tasks))
-            with Pool(processes=project.n_workers) as pool:
+            with Pool(processes=100) as pool:
                 masks = pool.starmap(_check_overlap, tasks, chunksize=100)
 
         else:

--- a/organelle_morphology/distance_calculations.py
+++ b/organelle_morphology/distance_calculations.py
@@ -399,6 +399,7 @@ def generate_distance_matrix(
                 client=project.client,
             )
 
+        # See #82 : usually slower than the regular domain decomposition
         elif chunk_dd:
             # only do domain decomposition if max dist is within one chunk
             chunksize = np.array(source.data.chunksize) * source.resolution

--- a/organelle_morphology/distance_calculations.py
+++ b/organelle_morphology/distance_calculations.py
@@ -11,7 +11,7 @@ from dask.distributed import span
 from scipy.spatial import KDTree
 
 import organelle_morphology
-from organelle_morphology.util import boxes_overlap
+from organelle_morphology.util import boxes_overlap, get_neighboring_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +261,7 @@ class MembraneContactSiteCalculator:
 def generate_distance_matrix(
     project: "organelle_morphology.Project",
     domain_decomposition=True,
+    chunk_dd=False,
 ) -> pd.DataFrame:
     cache = project.cache
     max_dist = project.max_distance
@@ -286,17 +287,8 @@ def generate_distance_matrix(
         organelles = np.array(project.organelles)
         organelles_ids = np.array([o.id for o in organelles])
         meshes = []
-        bounding_boxes = []
         for organelle in organelles:
             meshes.append(organelle.mesh)
-            # bounding_boxes.append(bounding_box_delayed(organelle.mesh))
-        with span("dist_matrix_bounding_boxes"):
-            # bounding_boxes = compute(bounding_boxes)[0]
-            # with many meshes (20k) ~30% faster then computing directly:
-            bounding_boxes = project.client.gather(
-                project.client.map(lambda m: m.compute().bounding_box.bounds, meshes)
-            )
-        print(f"bounding_boxes {len(bounding_boxes)}")
 
         project.logger.info("Calculating distance matrix")
         num_rows = len(meshes)
@@ -308,16 +300,20 @@ def generate_distance_matrix(
             columns=organelles_ids,
         )
 
+        if domain_decomposition and chunk_dd:
+            # TODO: automatically switch
+            domain_decomposition = False
+
         if domain_decomposition:
             # domain decomposition into chunks of
             # size = size of clipped data in units of the resolution
             size = np.array(source.resolution) * source.data.shape
             cube_size = max_dist * 10
-            stride = max_dist * 9
+            stride = max_dist * 8
             clp_of = source.clipping_corners[0]
-            n_x_cubes = min(max(int(size[0] // cube_size), 1), 50)
-            n_y_cubes = min(max(int(size[1] // cube_size), 1), 50)
-            n_z_cubes = min(max(int(size[2] // cube_size), 1), 50)
+            n_x_cubes = min(max(int(size[0] // stride), 1), 50)
+            n_y_cubes = min(max(int(size[1] // stride), 1), 50)
+            n_z_cubes = min(max(int(size[2] // stride), 1), 50)
 
             xs = np.linspace(
                 clp_of[0],
@@ -347,16 +343,53 @@ def generate_distance_matrix(
             )
             project.logger.debug(f"n organelles: {len(organelles)}")
 
+            project.logger.debug("Calculating bounding boxes")
+            bounding_boxes = []
+            with span("dist_matrix_bounding_boxes"):
+                # bounding_boxes = compute(bounding_boxes)[0]
+                # with many meshes (20k) ~30% faster then computing directly:
+                bounding_boxes = project.client.gather(
+                    project.client.map(
+                        lambda m: m.compute().bounding_box.bounds, meshes
+                    )
+                )
+            project.logger.debug(f"bounding_boxes {len(bounding_boxes)}")
+            project.logger.debug(
+                "bounding boxes finished, stating overlap calculations"
+            )
+
             tasks = []
             for x, y, z in zip(xg, yg, zg):
                 start = np.array((x, y, z))
-                end = start + stride
+                end = start + cube_size
                 box = (start, end)
                 tasks.append((box, bounding_boxes))
             # masks = list(map(lambda b: _check_overlap(b, bounding_boxes), tasks))
             with Pool(processes=100) as pool:
                 masks = pool.starmap(_check_overlap, tasks, chunksize=100)
 
+        elif chunk_dd:
+            # only do domain decomposition if max dist is within one chunk
+            if any([max_dist > r for r in source.resolution]):
+                masks = [np.ones((num_rows,))]
+                project.logger.debug("No domain decomposition as max_dist > chunksize")
+            else:
+                dshape = source.data.blocks.shape
+                domain_idxs = list(np.ndindex(dshape))
+                domains = [get_neighboring_chunks(idx, dshape) for idx in domain_idxs]
+                project.logger.debug(f"len domains {len(domains)}")
+
+                masks = [[] for _ in range(len(domains))]
+                for org in organelles:
+                    for i, idxs in enumerate(domains):
+                        if any([idx in org.chunks for idx in idxs]):
+                            masks[i].append(True)
+                        else:
+                            masks[i].append(False)
+
+                project.logger.debug(f"Masks unfiltered: {len(masks)}")
+                m_mask = [any(m) for m in masks]
+                masks = [m for i, m in enumerate(masks) if i in np.nonzero(m_mask)[0]]
         else:
             # no domain decomposition -> all to all
             masks = [np.ones((num_rows,))]
@@ -380,10 +413,18 @@ def generate_distance_matrix(
         project.logger.debug(f"n tasks get_min_dist: {len(tasks)}")
 
         with span("dist_matrix_min_dists"):
+            t0 = time()
             results = map(delayed_domain_min_dists, tasks)
+            t1 = time()
+            project.logger.debug(f"mapped delayed_min_dist, t {t1 - t0}")
             results = compute(results)[0]
+            t2 = time()
+            project.logger.debug(f"computed mapped, t {t2 - t1}")
             results = [r for res in results for r in res]
+            t3 = time()
+            project.logger.debug(f"iterated results, t {t3 - t2}")
 
+        project.logger.debug(f"Timings: {t1 - t0}, {t2 - t1}, {t3 - t2},")
         for res in results:
             distance_df.loc[res[0]] = res[1]
             distance_df.loc[res[0][::-1]] = res[1]

--- a/organelle_morphology/distance_calculations.py
+++ b/organelle_morphology/distance_calculations.py
@@ -11,7 +11,12 @@ from dask.distributed import span
 from scipy.spatial import KDTree
 
 import organelle_morphology
-from organelle_morphology.util import boxes_overlap, get_neighboring_chunks
+from organelle_morphology.util import (
+    block_to_coords,
+    bounding_box_delayed,
+    boxes_overlap,
+    get_neighboring_chunks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +50,84 @@ def delayed_domain_min_dists(args):
 
             tasks.append(get_min_dist((id_1, id_2, mesh_1, mesh_2, max_dist)))
     return tasks
+
+
+def make_domains(
+    size: np.ndarray, max_dist: float, start_corner: np.ndarray, meshes: np.ndarray
+):
+    """Decompose space into domains
+
+    Args:
+        size: max size of space to decompose.
+        max_dist: maximal contact distance which can be computed reliably.
+        start_corner: lowest corner of axis aligned bounding box of space.
+        meshes: list of meshes within the space to decompose.
+
+    Returns:
+        list[list[bool]]: binary masks
+    """
+
+    cube_size = max_dist * 100
+    stride = max_dist * 98
+    n_x_cubes = min(max(int(size[0] // stride), 1), 50)
+    n_y_cubes = min(max(int(size[1] // stride), 1), 50)
+    n_z_cubes = min(max(int(size[2] // stride), 1), 50)
+
+    xs = np.linspace(
+        start_corner[0],
+        size[0] + start_corner[0],
+        n_x_cubes,
+        endpoint=False,
+    )
+    ys = np.linspace(
+        start_corner[1],
+        size[1] + start_corner[1],
+        n_y_cubes,
+        endpoint=False,
+    )
+    zs = np.linspace(
+        start_corner[2],
+        size[2] + start_corner[2],
+        n_z_cubes,
+        endpoint=False,
+    )
+
+    xg, yg, zg = np.meshgrid(xs, ys, zs)
+    xg, yg, zg = list(map(lambda a: a.flatten(), (xg, yg, zg)))
+
+    logger.debug(f"Cube size: {cube_size}")
+    logger.debug(f"n cubes: {n_x_cubes}, {n_y_cubes}, {n_z_cubes} => {len(xg)}")
+
+    logger.debug("Calculating bounding boxes")
+    bounding_boxes = []
+    bounding_boxes = [bounding_box_delayed(m) for m in meshes]
+    with span("dist_matrix_bounding_boxes"):
+        bounding_boxes = compute(bounding_boxes)[0]
+        # with many meshes (20k) ~30% faster then computing directly:
+        # bounding_boxes = project.client.gather(
+        #     project.client.map(lambda m: m.compute().bounding_box.bounds, meshes)
+        # )
+    logger.debug(f"bounding_boxes {len(bounding_boxes)}")
+    logger.debug("bounding boxes finished, stating overlap calculations")
+
+    tasks = []
+    for x, y, z in zip(xg, yg, zg):
+        start = np.array((x, y, z))
+        end = start + cube_size
+        box = (start, end)
+        tasks.append((box, bounding_boxes))
+    # masks = list(map(lambda b: _check_overlap(b, bounding_boxes), tasks))
+    t0 = time()
+    with Pool(processes=100) as pool:
+        masks = pool.starmap(_check_overlap, tasks, chunksize=100)
+    logger.debug(f"pool overlap: {time() - t0}")
+
+    # remove masks with only one organelle
+    filtered_masks = []
+    for m in masks:
+        if np.count_nonzero(m) > 1:
+            filtered_masks.append(m)
+    return filtered_masks
 
 
 class MembraneContactSiteCalculator:
@@ -289,6 +372,7 @@ def generate_distance_matrix(
         meshes = []
         for organelle in organelles:
             meshes.append(organelle.mesh)
+        meshes = np.array(meshes)
 
         project.logger.info("Calculating distance matrix")
         num_rows = len(meshes)
@@ -300,73 +384,18 @@ def generate_distance_matrix(
             columns=organelles_ids,
         )
 
-        if domain_decomposition and chunk_dd:
-            # TODO: automatically switch
-            domain_decomposition = False
+        # if domain_decomposition and chunk_dd:
+        #     # TODO: automatically switch
+        #     domain_decomposition = False
 
-        if domain_decomposition:
+        if domain_decomposition and not chunk_dd:
             # domain decomposition into chunks of
-            # size = size of clipped data in units of the resolution
+            # size = size of clipped data in units of the resolution [um]
             size = np.array(source.resolution) * source.data.shape
-            cube_size = max_dist * 10
-            stride = max_dist * 8
-            clp_of = source.clipping_corners[0]
-            n_x_cubes = min(max(int(size[0] // stride), 1), 50)
-            n_y_cubes = min(max(int(size[1] // stride), 1), 50)
-            n_z_cubes = min(max(int(size[2] // stride), 1), 50)
-
-            xs = np.linspace(
-                clp_of[0],
-                size[0] + clp_of[0],
-                n_x_cubes,
-                endpoint=False,
+            clp_of = source.clipping_corners[0]  # lower corner clipping offset
+            masks = make_domains(
+                size=size, max_dist=max_dist, start_corner=clp_of, meshes=meshes
             )
-            ys = np.linspace(
-                clp_of[1],
-                size[1] + clp_of[1],
-                n_y_cubes,
-                endpoint=False,
-            )
-            zs = np.linspace(
-                clp_of[2],
-                size[2] + clp_of[2],
-                n_z_cubes,
-                endpoint=False,
-            )
-
-            xg, yg, zg = np.meshgrid(xs, ys, zs)
-            xg, yg, zg = list(map(lambda a: a.flatten(), (xg, yg, zg)))
-
-            project.logger.debug(f"Cube size: {cube_size}")
-            project.logger.debug(
-                f"n cubes: {n_x_cubes}, {n_y_cubes}, {n_z_cubes} => {len(xg)}"
-            )
-            project.logger.debug(f"n organelles: {len(organelles)}")
-
-            project.logger.debug("Calculating bounding boxes")
-            bounding_boxes = []
-            with span("dist_matrix_bounding_boxes"):
-                # bounding_boxes = compute(bounding_boxes)[0]
-                # with many meshes (20k) ~30% faster then computing directly:
-                bounding_boxes = project.client.gather(
-                    project.client.map(
-                        lambda m: m.compute().bounding_box.bounds, meshes
-                    )
-                )
-            project.logger.debug(f"bounding_boxes {len(bounding_boxes)}")
-            project.logger.debug(
-                "bounding boxes finished, stating overlap calculations"
-            )
-
-            tasks = []
-            for x, y, z in zip(xg, yg, zg):
-                start = np.array((x, y, z))
-                end = start + cube_size
-                box = (start, end)
-                tasks.append((box, bounding_boxes))
-            # masks = list(map(lambda b: _check_overlap(b, bounding_boxes), tasks))
-            with Pool(processes=100) as pool:
-                masks = pool.starmap(_check_overlap, tasks, chunksize=100)
 
         elif chunk_dd:
             # only do domain decomposition if max dist is within one chunk
@@ -390,7 +419,48 @@ def generate_distance_matrix(
 
                 project.logger.debug(f"Masks unfiltered: {len(masks)}")
                 m_mask = [any(m) for m in masks]
+                # primary masks over chunks
                 masks = [m for i, m in enumerate(masks) if i in np.nonzero(m_mask)[0]]
+
+                too_large = np.nonzero([len(np.nonzero(m)[0]) > 500 for m in masks])[0]
+                project.logger.debug(f"masks > 500: {len(too_large)}")
+
+                t0 = time()
+                clp_of = source.clipping_corners[0]  # lower corner clipping offset
+                for i in too_large[::-1]:
+                    mask = masks.pop(i)
+                    local_blocks = domains[i]
+                    local_meshes = meshes[mask]
+
+                    corners = np.array(
+                        [
+                            block_to_coords(b, source.resolution, source.data, clp_of)
+                            for b in local_blocks
+                        ]
+                    )
+                    lower_corner = corners.min(axis=0)[0]
+                    upper_corner = corners.max(axis=0)[1]
+                    size = upper_corner - lower_corner
+
+                    local_masks = make_domains(
+                        size=size,
+                        max_dist=max_dist,
+                        start_corner=lower_corner,
+                        meshes=local_meshes,
+                    )
+                    for local_mask in local_masks:
+                        global_mask = np.zeros_like(meshes, dtype=bool)
+                        global_mask[mask] = local_mask
+                        masks.append(global_mask)
+
+                    project.logger.debug(
+                        f"decomposed {np.count_nonzero(mask)} orgs into {len(local_masks)}"
+                    )
+
+                project.logger.debug(
+                    f"Decomposed {len(too_large)} chunks into {len(masks)} domains in {time() - t0} s"
+                )
+
         else:
             # no domain decomposition -> all to all
             masks = [np.ones((num_rows,))]

--- a/organelle_morphology/distance_calculations.py
+++ b/organelle_morphology/distance_calculations.py
@@ -370,7 +370,8 @@ def generate_distance_matrix(
 
         elif chunk_dd:
             # only do domain decomposition if max dist is within one chunk
-            if any([max_dist > r for r in source.resolution]):
+            chunksize = np.array(source.data.chunksize) * source.resolution
+            if any([max_dist > r for r in chunksize]):
                 masks = [np.ones((num_rows,))]
                 project.logger.debug("No domain decomposition as max_dist > chunksize")
             else:

--- a/organelle_morphology/distance_calculations.py
+++ b/organelle_morphology/distance_calculations.py
@@ -13,7 +13,6 @@ from scipy.spatial import KDTree
 import organelle_morphology
 from organelle_morphology.util import (
     block_to_coords,
-    bounding_box_delayed,
     boxes_overlap,
     get_neighboring_chunks,
 )
@@ -53,7 +52,11 @@ def delayed_domain_min_dists(args):
 
 
 def make_domains(
-    size: np.ndarray, max_dist: float, start_corner: np.ndarray, meshes: np.ndarray
+    size: np.ndarray,
+    max_dist: float,
+    start_corner: np.ndarray,
+    meshes: np.ndarray,
+    client,
 ):
     """Decompose space into domains
 
@@ -67,11 +70,12 @@ def make_domains(
         list[list[bool]]: binary masks
     """
 
-    cube_size = max_dist * 100
-    stride = max_dist * 98
-    n_x_cubes = min(max(int(size[0] // stride), 1), 50)
-    n_y_cubes = min(max(int(size[1] // stride), 1), 50)
-    n_z_cubes = min(max(int(size[2] // stride), 1), 50)
+    stride = max_dist * 100
+    n_x_cubes = min(max(int(size[0] // stride), 1), 20)
+    n_y_cubes = min(max(int(size[1] // stride), 1), 20)
+    n_z_cubes = min(max(int(size[2] // stride), 1), 20)
+    cube_size = size / np.array([n_x_cubes, n_y_cubes, n_z_cubes])
+    cube_size += 2 * max_dist
 
     xs = np.linspace(
         start_corner[0],
@@ -100,13 +104,11 @@ def make_domains(
 
     logger.debug("Calculating bounding boxes")
     bounding_boxes = []
-    bounding_boxes = [bounding_box_delayed(m) for m in meshes]
     with span("dist_matrix_bounding_boxes"):
-        bounding_boxes = compute(bounding_boxes)[0]
         # with many meshes (20k) ~30% faster then computing directly:
-        # bounding_boxes = project.client.gather(
-        #     project.client.map(lambda m: m.compute().bounding_box.bounds, meshes)
-        # )
+        bounding_boxes = client.gather(
+            client.map(lambda m: m.compute().bounding_box.bounds, meshes)
+        )
     logger.debug(f"bounding_boxes {len(bounding_boxes)}")
     logger.debug("bounding boxes finished, stating overlap calculations")
 
@@ -384,17 +386,17 @@ def generate_distance_matrix(
             columns=organelles_ids,
         )
 
-        # if domain_decomposition and chunk_dd:
-        #     # TODO: automatically switch
-        #     domain_decomposition = False
-
         if domain_decomposition and not chunk_dd:
             # domain decomposition into chunks of
             # size = size of clipped data in units of the resolution [um]
             size = np.array(source.resolution) * source.data.shape
             clp_of = source.clipping_corners[0]  # lower corner clipping offset
             masks = make_domains(
-                size=size, max_dist=max_dist, start_corner=clp_of, meshes=meshes
+                size=size,
+                max_dist=max_dist,
+                start_corner=clp_of,
+                meshes=meshes,
+                client=project.client,
             )
 
         elif chunk_dd:
@@ -410,12 +412,21 @@ def generate_distance_matrix(
                 project.logger.debug(f"len domains {len(domains)}")
 
                 masks = [[] for _ in range(len(domains))]
-                for org in organelles:
-                    for i, idxs in enumerate(domains):
-                        if any([idx in org.chunks for idx in idxs]):
+                for i, idxs in enumerate(domains):
+                    has_org_in_center = False
+                    for org in organelles:
+                        # in central block of domain:
+                        if domain_idxs[i] in org.chunks:
                             masks[i].append(True)
+                            has_org_in_center = True
+                        # in neighbor block of domain:
+                        elif any([idx in org.chunks for idx in idxs]):
+                            masks[i].append(True)
+                        # not in domain:
                         else:
                             masks[i].append(False)
+                    if not has_org_in_center:
+                        masks[i] = []
 
                 project.logger.debug(f"Masks unfiltered: {len(masks)}")
                 m_mask = [any(m) for m in masks]
@@ -425,41 +436,44 @@ def generate_distance_matrix(
                 too_large = np.nonzero([len(np.nonzero(m)[0]) > 500 for m in masks])[0]
                 project.logger.debug(f"masks > 500: {len(too_large)}")
 
-                t0 = time()
-                clp_of = source.clipping_corners[0]  # lower corner clipping offset
-                for i in too_large[::-1]:
-                    mask = masks.pop(i)
-                    local_blocks = domains[i]
-                    local_meshes = meshes[mask]
+                if domain_decomposition:
+                    t0 = time()
+                    clp_of = source.clipping_corners[0]  # lower corner clipping offset
+                    for i in too_large[::-1]:
+                        mask = masks.pop(i)
+                        local_blocks = domains[i]
+                        local_meshes = meshes[mask]
 
-                    corners = np.array(
-                        [
-                            block_to_coords(b, source.resolution, source.data, clp_of)
-                            for b in local_blocks
-                        ]
-                    )
-                    lower_corner = corners.min(axis=0)[0]
-                    upper_corner = corners.max(axis=0)[1]
-                    size = upper_corner - lower_corner
+                        corners = np.array(
+                            [
+                                block_to_coords(
+                                    b, source.resolution, source.data, clp_of
+                                )
+                                for b in local_blocks
+                            ]
+                        )
+                        lower_corner = corners.min(axis=0)[0]
+                        upper_corner = corners.max(axis=0)[1]
+                        size = upper_corner - lower_corner
 
-                    local_masks = make_domains(
-                        size=size,
-                        max_dist=max_dist,
-                        start_corner=lower_corner,
-                        meshes=local_meshes,
-                    )
-                    for local_mask in local_masks:
-                        global_mask = np.zeros_like(meshes, dtype=bool)
-                        global_mask[mask] = local_mask
-                        masks.append(global_mask)
+                        local_masks = make_domains(
+                            size=size,
+                            max_dist=max_dist,
+                            start_corner=lower_corner,
+                            meshes=local_meshes,
+                        )
+                        for local_mask in local_masks:
+                            global_mask = np.zeros_like(meshes, dtype=bool)
+                            global_mask[mask] = local_mask
+                            masks.append(global_mask)
+
+                        project.logger.debug(
+                            f"decomposed {np.count_nonzero(mask)} orgs into {len(local_masks)}"
+                        )
 
                     project.logger.debug(
-                        f"decomposed {np.count_nonzero(mask)} orgs into {len(local_masks)}"
+                        f"Decomposed {len(too_large)} chunks into {len(masks)} domains in {time() - t0} s"
                     )
-
-                project.logger.debug(
-                    f"Decomposed {len(too_large)} chunks into {len(masks)} domains in {time() - t0} s"
-                )
 
         else:
             # no domain decomposition -> all to all

--- a/organelle_morphology/organelle.py
+++ b/organelle_morphology/organelle.py
@@ -110,6 +110,7 @@ class Organelle:
         self._sampled_skeleton = None
         self._skeleton_info = {}
         self._mcs = defaultdict(dict)
+        self._chunks = None
 
     @classmethod
     def construct(cls, source, labels: list[int]):
@@ -134,6 +135,12 @@ class Organelle:
         return OrganelleMetadata(
             source=self.source.xml_path, label=self.label, id=self._organelle_id
         )
+
+    @property
+    def chunks(self):
+        if self._chunks is None:
+            self._chunks = self.source.ids_to_chunks[self.label]
+        return self._chunks
 
     def plotly_skeleton(self):
         if self._skeleton is None:

--- a/organelle_morphology/organelle.py
+++ b/organelle_morphology/organelle.py
@@ -313,7 +313,7 @@ class Organelle:
         return self._organelle_id
 
     @property
-    def bounding_box(self) -> Delayed:
+    def bounding_box(self) -> tuple[np.ndarray, np.ndarray]:
         return bounding_box_delayed(self.mesh).compute()
 
     @property

--- a/organelle_morphology/organelle.py
+++ b/organelle_morphology/organelle.py
@@ -79,6 +79,11 @@ class McsData(PropertyBlock):
     std_area: float
     mean_dist: float
     std_dist: float
+    min_dist: float
+    max_dist: float
+    partners: list[str]
+    min_dist_per_org: list[float]
+    max_dist_per_org: list[float]
     n_contacts_per_area: float
     n_contacts_per_volume: float
     area_per_area: float
@@ -389,13 +394,18 @@ class Organelle:
         mean_dist_list = []
         std_dist_list = []
         area_list = []
+        partners = []
+        min_dist_list = []
+        max_dist_list = []
 
-        for entries in self.mcs[mcs_label].values():
-            mean_dist_list.append(np.mean(entries["distances"]))
-            std_dist_list.append(np.std(entries["distances"]))
-            len_dist_list.append(len(entries["distances"]))
-
-            area_list.append(entries["area"])
+        for partner, entry in self.mcs[mcs_label].items():
+            partners.append(partner)
+            mean_dist_list.append(np.mean(entry["distances"]))
+            std_dist_list.append(np.std(entry["distances"]))
+            len_dist_list.append(len(entry["distances"]))
+            min_dist_list.append(np.min(entry["distances"]))
+            max_dist_list.append(np.max(entry["distances"]))
+            area_list.append(entry["area"])
 
         mean_dist_list = np.array(mean_dist_list)
         std_dist_list = np.array(std_dist_list)
@@ -405,12 +415,16 @@ class Organelle:
                 "No distributions found for mcs %s in organelle %s", mcs_label, self
             )
             return
-        assert entries
+        assert entry
 
         mcs_dict["n_contacts"] = len(len_dist_list)
+        mcs_dict["partners"] = partners
 
-        mcs_dict["total_area"] = np.sum(entries["area"])
+        mcs_dict["total_area"] = np.sum(area_list)
         mcs_dict["mean_area"] = np.mean(area_list)
+
+        mcs_dict["min_dist"] = np.min(min_dist_list)
+        mcs_dict["max_dist"] = np.max(max_dist_list)
 
         if len(area_list) == 1:
             mcs_dict["std_area"] = 0
@@ -435,6 +449,9 @@ class Organelle:
         mcs_dict["mean_dist"] = overall_mean
         mcs_dict["std_dist"] = overall_std
 
+        mcs_dict["min_dist_per_org"] = min_dist_list
+        mcs_dict["max_dist_per_org"] = max_dist_list
+
         mcs_dict["n_contacts_per_area"] = mcs_dict["n_contacts"] / surface
         mcs_dict["n_contacts_per_volume"] = mcs_dict["n_contacts"] / volume
 
@@ -445,8 +462,8 @@ class Organelle:
         mcs_meta = McsMetadata(
             organelle_meta=self.metadata,
             mcs_label=mcs_label,
-            min_dist=entries["meta"]["min_distance"],
-            max_dist=entries["meta"]["max_distance"],
+            min_dist=entry["meta"]["min_distance"],
+            max_dist=entry["meta"]["max_distance"],
         )
         stat = Record(mcs_props, mcs_meta, project=self.project)
         self.project.registry.add(stat)

--- a/organelle_morphology/project.py
+++ b/organelle_morphology/project.py
@@ -1123,17 +1123,19 @@ class Project:
         self._cache = None
         self.registry = RecordRegistry(self)
 
-    def clear_caches(self, clear_disk=False):
+    def clear_caches(self, clear_disk=False, silent=False):
         """Clear all caches related to this project, optionally also from disk"""
 
         for source in self.sources.values():
             source.clear_memory_cache()
         self.clear_memory_cache()
-        self.logger.debug("Cleared memory cache of all sources.")
+        if not silent:
+            self.logger.debug("Cleared memory cache of all sources.")
 
         if clear_disk:
             # iterate over what is on disk rather than the currently loaded sources
             i = -1
             for i, cache in enumerate(self.get_caches()):
                 cache.clear_disk_cache()
-            self.logger.info(f"Deleted {i + 1} caches from disk.")
+            if not silent:
+                self.logger.info(f"Deleted {i + 1} caches from disk.")

--- a/organelle_morphology/project.py
+++ b/organelle_morphology/project.py
@@ -1058,7 +1058,7 @@ class Project:
             mesh = mesh.compute()
         return mesh
 
-    def get_caches(self) -> list[Cache]:
+    def get_caches(self, silent=False) -> list[Cache]:
         caches = []
         cs = self.cache_settings
         cache_dir = cs["cache_root"] / f"cache_{cs['project_name']}"
@@ -1100,8 +1100,9 @@ class Project:
                 if s._cache.cache_name not in cache_names:
                     caches.append(s.cache)
 
-        self.logger.info("\n".join(messages))
-        self.logger.info(f"Found {len(caches)} caches for project {self.path.name}")
+        if not silent:
+            self.logger.info("\n".join(messages))
+            self.logger.info(f"Found {len(caches)} caches for project {self.path.name}")
         return caches
 
     @property
@@ -1135,7 +1136,7 @@ class Project:
         if clear_disk:
             # iterate over what is on disk rather than the currently loaded sources
             i = -1
-            for i, cache in enumerate(self.get_caches()):
+            for i, cache in enumerate(self.get_caches(silent=silent)):
                 cache.clear_disk_cache()
             if not silent:
                 self.logger.info(f"Deleted {i + 1} caches from disk.")

--- a/organelle_morphology/source.py
+++ b/organelle_morphology/source.py
@@ -487,6 +487,16 @@ class DataSource:
             return ids_to_chunks
 
     @property
+    def chunks_to_ids(self):
+        if "chunks_to_ids " not in self.cache:
+            chunks_to_ids = defaultdict(list)
+            for id_, chunks in self.ids_to_chunks.items():
+                for chunk in chunks:
+                    chunks_to_ids[chunk].append(id_)
+            self.cache["chunks_to_ids"] = chunks_to_ids
+        return self.cache["chunks_to_ids"]
+
+    @property
     def mesh_fragments(self) -> tuple[dict[int, list[tuple[int]]], np.ndarray]:
         """Get the mesh fragments from cache, or calculate them.
 

--- a/organelle_morphology/util.py
+++ b/organelle_morphology/util.py
@@ -221,6 +221,31 @@ def merge_delayed_trimeshes(tmeshes: list[Trimesh]):
     return tmesh
 
 
+def get_neighboring_chunks(index: tuple[int, ...], shape: tuple[int, ...]):
+    """Get all indeces of a give index within a defined matrix.
+
+    Args:
+        index: 3d index, get neighbors of this index
+        shape: 3d shape of the matrix
+    """
+    neighbors = []
+    x, y, z = index
+    dim_x, dim_y, dim_z = shape
+
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for dz in (-1, 0, 1):
+                if dx == 0 and dy == 0 and dz == 0:
+                    continue
+
+                nx, ny, nz = x + dx, y + dy, z + dz
+
+                if 0 <= nx < dim_x and 0 <= ny < dim_y and 0 <= nz < dim_z:
+                    neighbors.append((nx, ny, nz))
+
+    return neighbors
+
+
 def sample_skeleton(skeleton, path_sample_dist: float = 0.1):
     # the sample points are points along the skeleton arms
     # and the reference points are the vertices of the skeleton from which

--- a/organelle_morphology/util.py
+++ b/organelle_morphology/util.py
@@ -365,6 +365,20 @@ def bounding_box_delayed(mesh: Trimesh):
     return min, max
 
 
+def block_to_coords(block, resolution, data, offset=[0, 0, 0]):
+    resolution = np.array(resolution)
+    block_coords = [
+        of + (np.cumsum(cs) * res)
+        for cs, res, of in zip(data.chunks, resolution, offset)
+    ]
+    block_coords = [np.concat([[of], bc]) for bc, of in zip(block_coords, offset)]
+
+    lower_corner = [block_coords[d][b] for d, b in enumerate(block)]
+    upper_corner = [block_coords[d][b + 1] for d, b in enumerate(block)]
+
+    return lower_corner, upper_corner
+
+
 def show(meshes):
     """Set up a scene with proper camera settings and show it"""
     scene = trimesh.Scene()

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -21,6 +21,7 @@ from dask.distributed import LocalCluster, Client
 import organelle_morphology as om
 from organelle_morphology.util import color_delayed_trimesh_rgba, show
 from organelle_morphology.position import Position_Analysis
+from organelle_morphology.analysis import Mcs_Analysis
 
 viridis = mpl.colormaps.get("viridis")
 # %%

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 from dask.base import compute
 from dask.distributed import LocalCluster, Client
 import organelle_morphology as om
+from organelle_morphology.distance_calculations import generate_distance_matrix
 from organelle_morphology.util import color_delayed_trimesh_rgba, show
 from organelle_morphology.position import Position_Analysis
 from organelle_morphology.analysis import Mcs_Analysis
@@ -57,6 +58,46 @@ p.compression_level = "s2"
 t0 = time()
 merge_meshes(list(s.meshes.values())).compute()
 print("Done in: ", time() - t0)
+
+# %% bench domain decomp
+p.clear_caches(True)
+p.clipping = [[0.6,0.5,0.5], [1,1,1]]
+p.compression_level = "s2"
+p.max_distance = 0.01
+t0 = time()
+generate_distance_matrix(project=p,domain_decomposition=True)
+t_dd = time() - t0
+print("Done in: ", t_dd )
+
+p.clear_caches(True)
+p.clipping = [[0.6,0.5,0.5], [1,1,1]]
+p.compression_level = "s2"
+p.max_distance = 0.01
+t0 = time()
+generate_distance_matrix(project=p,chunk_dd=False)
+t_chunks = time() - t0
+print("chunks: ", t_chunks )
+print("domains: ", t_dd )
+
+
+p.clear_caches(True)
+p.clipping = [[0.60,0.45,0.5], [0.75,0.8,0.6]]
+p.compression_level = "s1"
+p.max_distance = 0.01
+t0 = time()
+generate_distance_matrix(project=p,domain_decomposition=True)
+t_dd_s1 = time() - t0
+print("Done in: ", t_dd_s1 )
+
+p.clear_caches(True)
+p.clipping = [[0.67,0.45,0.5], [0.73,0.8,0.6]]
+p.compression_level = "s1"
+p.max_distance = 0.01
+t0 = time()
+generate_distance_matrix(project=p,chunk_dd=False)
+t_chunks_s1 = time() - t0
+print("chunks: ", t_chunks_s1 )
+print("domains: ", t_dd_s1 )
 
 
 # %% benchmark

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -74,7 +74,7 @@ p.clipping = [[0.6,0.5,0.5], [1,1,1]]
 p.compression_level = "s2"
 p.max_distance = 0.01
 t0 = time()
-generate_distance_matrix(project=p,chunk_dd=False)
+generate_distance_matrix(project=p,domain_decomposition=False,chunk_dd=True)
 t_chunks = time() - t0
 print("chunks: ", t_chunks )
 print("domains: ", t_dd )
@@ -90,11 +90,11 @@ t_dd_s1 = time() - t0
 print("Done in: ", t_dd_s1 )
 
 p.clear_caches(True)
-p.clipping = [[0.67,0.45,0.5], [0.73,0.8,0.6]]
+p.clipping = [[0.60,0.45,0.5], [0.75,0.8,0.6]]
 p.compression_level = "s1"
 p.max_distance = 0.01
 t0 = time()
-generate_distance_matrix(project=p,chunk_dd=False)
+generate_distance_matrix(project=p,domain_decomposition=False,chunk_dd=True)
 t_chunks_s1 = time() - t0
 print("chunks: ", t_chunks_s1 )
 print("domains: ", t_dd_s1 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 
+from distributed import LocalCluster
 from distributed.utils_test import (
     client,  # noqa: F401
     loop,  # noqa: F401
@@ -160,21 +161,21 @@ def project_path(synthetic_data):
     return synthetic_data[0]
 
 
-# @pytest.fixture(scope="session")
-# def cluster():
-#     if resource is not None:
-#         resource.setrlimit(resource.RLIMIT_NOFILE, (10000, 10000))
-#
-#     cluster = LocalCluster(dashboard_address=None)
-#     yield cluster
-#     cluster.close()
-#
-#
-# @pytest.fixture(scope="function")
-# def custom_client(cluster):
-#     cclient = cluster.get_client()
-#     yield cclient
-#     cclient.close()
+@pytest.fixture(scope="session")
+def cluster():
+    if resource is not None:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (10000, 10000))
+
+    cluster = LocalCluster(dashboard_address=None)
+    yield cluster
+    cluster.close()
+
+
+@pytest.fixture(scope="function")
+def custom_client(cluster):
+    cclient = cluster.get_client()
+    yield cclient
+    cclient.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Optional
 
 
-from dask.distributed import LocalCluster
 from distributed.utils_test import (
     client,  # noqa: F401
     loop,  # noqa: F401
@@ -161,21 +160,21 @@ def project_path(synthetic_data):
     return synthetic_data[0]
 
 
-@pytest.fixture(scope="session")
-def cluster():
-    if resource is not None:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (10000, 10000))
-
-    cluster = LocalCluster(dashboard_address=None)
-    yield cluster
-    cluster.close()
-
-
-@pytest.fixture(scope="function")
-def custom_client(cluster):
-    cclient = cluster.get_client()
-    yield cclient
-    cclient.close()
+# @pytest.fixture(scope="session")
+# def cluster():
+#     if resource is not None:
+#         resource.setrlimit(resource.RLIMIT_NOFILE, (10000, 10000))
+#
+#     cluster = LocalCluster(dashboard_address=None)
+#     yield cluster
+#     cluster.close()
+#
+#
+# @pytest.fixture(scope="function")
+# def custom_client(cluster):
+#     cclient = cluster.get_client()
+#     yield cclient
+#     cclient.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def project(project_path, client):  # noqa: F811
     """A fixture for a valid project instance"""
     project = Project(project_path, client=client)
     yield project
-    project.clear_caches(True)
+    project.clear_caches(True, silent=True)
 
 
 @pytest.fixture
@@ -191,4 +191,4 @@ def project_with_sources(project):
     """A fixture for a valid project instance, incl. added sources"""
     project.add_source("synth_data", "mito")
     yield project
-    project.clear_caches(True)
+    project.clear_caches(True, silent=True)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -63,6 +63,11 @@ def test_statistics_mcs_aggregation(project_with_sources):
         std_area=0.0,
         mean_dist=42.0,
         std_dist=0.0,
+        min_dist=0.1,
+        max_dist=0.1,
+        partners="other_one",
+        min_dist_per_org=[0.1],
+        max_dist_per_org=[0.1],
         n_contacts_per_area=0.1,
         n_contacts_per_volume=0.1,
         area_per_area=0.1,
@@ -78,10 +83,10 @@ def test_statistics_mcs_aggregation(project_with_sources):
     props = ["total_area", "mean_dist", "volume"]  # Request contact keys
     df = stats.get_dataframe(ids="mito_0001", properties=props)
 
-    assert df.iloc[0]["0-0.01-total_area"] == 150.5  # Verify
-    assert df.iloc[0]["0-0.01-mean_dist"] == 42.0  # Verify
+    assert df.iloc[0]["0-0.01-total_area"] == 150.5
+    assert df.iloc[0]["0-0.01-mean_dist"] == 42.0
 
-    summary_df = stats.get_summary_dataframe(df)  # Verify the summary
+    summary_df = stats.get_summary_dataframe(df)
     avg_row = summary_df[summary_df["Measure"] == "Average (or Share)"].iloc[0]
     assert avg_row["0-0.01-total_area"] == 150.5
 

--- a/tests/test_distance_calculations.py
+++ b/tests/test_distance_calculations.py
@@ -48,15 +48,22 @@ def test_distance_matrix_incomplete_dd_compair(project_with_sources):
     df3 = generate_distance_matrix(
         project_with_sources, domain_decomposition=False, chunk_dd=True
     )
+    project_with_sources.clear_caches(True)
+    project_with_sources.max_distance = 10
+    df4 = generate_distance_matrix(
+        project_with_sources, domain_decomposition=True, chunk_dd=True
+    )
 
     idxs = np.nonzero((0 <= df) & (df <= 10))
     pairs = list(zip(*idxs))
 
     assert all([df.iloc[p] == df2.iloc[p] for p in pairs])
     assert all([df.iloc[p] == df3.iloc[p] for p in pairs])
+    assert all([df.iloc[p] == df4.iloc[p] for p in pairs])
 
     assert np.all(df == df2)
     assert np.all(df == df3)
+    assert np.all(df == df4)
 
 
 def test_distance_matrix_no_source(project):

--- a/tests/test_distance_calculations.py
+++ b/tests/test_distance_calculations.py
@@ -28,13 +28,22 @@ def test_distance_matrix(project_with_sources):
 
 def test_distance_matrix_incomplete(project_with_sources):
     project_with_sources.max_distance = 10
-    df = generate_distance_matrix(project_with_sources)
+    df = generate_distance_matrix(project_with_sources, domain_decomposition=True)
     assert isinstance(df, DataFrame)
     assert df.shape == (19, 19)
     assert (df < 0).sum().sum() == 347
     for ind, row in df.iterrows():
         assert row.loc[df.index[3]] == df.loc[df.index[3], ind]
         assert row.pop(ind) == -1.0
+
+
+def test_distance_matrix_incomplete_no_domain_decomp(project_with_sources):
+    project_with_sources.max_distance = 10
+    df = generate_distance_matrix(project_with_sources, domain_decomposition=False)
+    project_with_sources.clear_caches(True)
+    project_with_sources.max_distance = 10
+    df2 = generate_distance_matrix(project_with_sources, domain_decomposition=True)
+    assert np.all(df == df2)
 
 
 def test_distance_matrix_no_source(project):

--- a/tests/test_distance_calculations.py
+++ b/tests/test_distance_calculations.py
@@ -31,19 +31,32 @@ def test_distance_matrix_incomplete(project_with_sources):
     df = generate_distance_matrix(project_with_sources, domain_decomposition=True)
     assert isinstance(df, DataFrame)
     assert df.shape == (19, 19)
-    assert (df < 0).sum().sum() == 347
+    assert (df < 0).sum().sum() == 343
     for ind, row in df.iterrows():
         assert row.loc[df.index[3]] == df.loc[df.index[3], ind]
         assert row.pop(ind) == -1.0
 
 
-def test_distance_matrix_incomplete_no_domain_decomp(project_with_sources):
+def test_distance_matrix_incomplete_dd_compair(project_with_sources):
     project_with_sources.max_distance = 10
     df = generate_distance_matrix(project_with_sources, domain_decomposition=False)
     project_with_sources.clear_caches(True)
     project_with_sources.max_distance = 10
     df2 = generate_distance_matrix(project_with_sources, domain_decomposition=True)
+    project_with_sources.clear_caches(True)
+    project_with_sources.max_distance = 10
+    df3 = generate_distance_matrix(
+        project_with_sources, domain_decomposition=False, chunk_dd=True
+    )
+
+    idxs = np.nonzero((0 <= df) & (df <= 10))
+    pairs = list(zip(*idxs))
+
+    assert all([df.iloc[p] == df2.iloc[p] for p in pairs])
+    assert all([df.iloc[p] == df3.iloc[p] for p in pairs])
+
     assert np.all(df == df2)
+    assert np.all(df == df3)
 
 
 def test_distance_matrix_no_source(project):

--- a/tests/test_mcs_analysis.py
+++ b/tests/test_mcs_analysis.py
@@ -52,7 +52,7 @@ def test_mcs(project_with_sources, rep):
 
     analysis = Mcs_Analysis(project_with_sources)
     props = analysis.get_mcs_properties()
-    assert props.shape == (10, 10)
+    assert props.shape == (11, 15)
 
     overview = analysis.get_mcs_overview()
     assert overview.shape == (10, 1)

--- a/tests/test_organelle.py
+++ b/tests/test_organelle.py
@@ -40,8 +40,8 @@ def test_get_mesh_mcs_colored(project_with_sources):
     project_with_sources.search_mcs(10)
     o = project_with_sources.get_organelles("mito_0015")[0]
     mesh = o.get_mesh_mcs_colored().compute()
-    # has two different mcs
-    assert np.unique(mesh.visual.vertex_colors, axis=0).shape == (3, 4)
+    # has three different mcs
+    assert np.unique(mesh.visual.vertex_colors, axis=0).shape == (4, 4)
 
 
 def test_get_mesh_mcs_colored_missing(project_with_sources):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -284,8 +284,8 @@ def test_mcs_dicts(project_with_sources):
     p.search_mcs(10)
     mcs_dicts = s.mcs_dicts
     assert list(mcs_dicts.keys()) == ["0.0-10,-"]
-    assert len(mcs_dicts["0.0-10,-"]) == 10
-    assert len(mcs_dicts["0.0-10,-"]["mito_0019"]) == 2
+    assert len(mcs_dicts["0.0-10,-"]) == 11
+    assert len(mcs_dicts["0.0-10,-"]["mito_0019"]) == 3
     assert all(
         k in mcs_dicts["0.0-10,-"]["mito_0019"]["mito_0015"].keys()
         for k in ["area", "distances", "vertices_index"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,7 @@
-from organelle_morphology.util import measure_gaussian_curvature_delayed
+from organelle_morphology.util import (
+    get_neighboring_chunks,
+    measure_gaussian_curvature_delayed,
+)
 
 
 def test_measure_curvature_parametrized(project_with_sources):
@@ -8,3 +11,82 @@ def test_measure_curvature_parametrized(project_with_sources):
     delayed = measure_gaussian_curvature_delayed(tmesh=mesh, radius=1)
     curv = delayed.compute()
     assert curv.shape == (866,)
+
+
+def test_central_index_returns_26_neighbors():
+    shape = (5, 5, 5)
+    index = (2, 2, 2)  # Center
+    neighbors = get_neighboring_chunks(index, shape)
+
+    assert len(neighbors) == 26, f"Expected 26 neighbors, got {len(neighbors)}"
+
+    # Verify all neighbors are unique
+    assert len(set(neighbors)) == 26, "Neighbors should all be unique"
+
+    # Verify none of the neighbors are the center itself
+    assert index not in neighbors, "Neighbors should not include the center index"
+
+    # Verify all indices are within bounds
+    for nx, ny, nz in neighbors:
+        assert 0 <= nx < shape[0], f"nx={nx} out of bounds"
+        assert 0 <= ny < shape[1], f"ny={ny} out of bounds"
+        assert 0 <= nz < shape[2], f"nz={nz} out of bounds"
+
+
+def test_corner_index_returns_7_neighbors():
+    shape = (5, 5, 5)
+    corners = [
+        (0, 0, 0),
+        (0, 0, 4),
+        (0, 4, 0),
+        (0, 4, 4),
+        (4, 0, 0),
+        (4, 0, 4),
+        (4, 4, 0),
+        (4, 4, 4),
+    ]
+
+    for corner in corners:
+        neighbors = get_neighboring_chunks(corner, shape)
+        assert len(neighbors) == 7, (
+            f"Corner {corner} should have 7 neighbors, got {len(neighbors)}"
+        )
+
+        # Verify all neighbors are within bounds
+        for nx, ny, nz in neighbors:
+            assert 0 <= nx < shape[0]
+            assert 0 <= ny < shape[1]
+            assert 0 <= nz < shape[2]
+
+        # Verify center is not included
+        assert corner not in neighbors
+
+
+def test_edge_index_returns_11_neighbors():
+    shape = (5, 5, 5)
+    edge_index = (0, 2, 2)  # On one face, not a corner
+    neighbors = get_neighboring_chunks(edge_index, shape)
+
+    assert len(neighbors) == 11, (
+        f"Edge index should have 11 neighbors, got {len(neighbors)}"
+    )
+
+
+def test_face_index_returns_17_neighbors():
+    shape = (5, 5, 5)
+    face_index = (0, 0, 2)  # On edge between two faces
+    neighbors = get_neighboring_chunks(face_index, shape)
+
+    assert len(neighbors) == 17, (
+        f"Edge-indexed face should have 17 neighbors, got {len(neighbors)}"
+    )
+
+
+def test_small_matrix_1x1x1():
+    shape = (1, 1, 1)
+    index = (0, 0, 0)
+    neighbors = get_neighboring_chunks(index, shape)
+
+    assert len(neighbors) == 0, (
+        f"1x1x1 matrix should have 0 neighbors, got {len(neighbors)}"
+    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -67,7 +67,7 @@ def test_corner_index_returns_7_neighbors():
 
 def test_edge_index_returns_11_neighbors():
     shape = (5, 5, 5)
-    edge_index = (0, 2, 2)  # On one face, not a corner
+    edge_index = (0, 0, 2)  # On one face, not a corner
     neighbors = get_neighboring_chunks(edge_index, shape)
 
     assert len(neighbors) == 11, (
@@ -77,11 +77,11 @@ def test_edge_index_returns_11_neighbors():
 
 def test_face_index_returns_17_neighbors():
     shape = (5, 5, 5)
-    face_index = (0, 0, 2)  # On edge between two faces
+    face_index = (0, 2, 2)  # On edge between two faces
     neighbors = get_neighboring_chunks(face_index, shape)
 
     assert len(neighbors) == 17, (
-        f"Edge-indexed face should have 17 neighbors, got {len(neighbors)}"
+        f"Face index should have 17 neighbors, got {len(neighbors)}"
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,10 @@
 from organelle_morphology.util import (
+    block_to_coords,
     get_neighboring_chunks,
     measure_gaussian_curvature_delayed,
 )
+import numpy as np
+import dask.array as da
 
 
 def test_measure_curvature_parametrized(project_with_sources):
@@ -90,3 +93,18 @@ def test_small_matrix_1x1x1():
     assert len(neighbors) == 0, (
         f"1x1x1 matrix should have 0 neighbors, got {len(neighbors)}"
     )
+
+
+def test_block_to_coords():
+    data = da.from_array(np.empty((100, 60, 20)), chunks=18)
+    last_corner = [-1, -1, -1]
+    for block in np.ndindex(data.blocks.shape):
+        lc, uc = block_to_coords(block, (0.03, 0.02, 0.1), data, [10, 20, 30])
+        assert np.any([c > last_c for c, last_c in zip(lc, last_corner)])
+        assert len(lc) == 3
+        assert len(uc) == 3
+        assert np.all(lc < uc)
+        assert lc[0] >= 10
+        assert lc[1] >= 20
+        assert lc[2] >= 30
+        last_corner = lc


### PR DESCRIPTION
Domain decomposition did lead to missing distance calculations so far.

This PR adds a new method based on data chunks, and fixes the old domain decomposition code.
Which method is faster depends on the domain size and chunk numbers:

|S2|||S1||
|---|---|---|---|---|
|chunks|domains||chunks|domains|
|1127s|92s||2986s|5314s|
|80 domains|125000 cubes||72 domains|107500 cubes|
|34 filled|3900 filled||72 filled|44000 filled|
|**Data**|||||
|1500 organelles|||1500 organelles||
|max ch/org:|1 org in 11 chunks|||1 org in 39 chunks|
|80 chunks|||72 chunks||
|noclip: 504 chunks|||noclip: 4000 chunks||

after fixing clipped cube size and adjusting stride:
|S2||S1||
|---|---|---|---|
|120 s|40 s|1208 s|137 s|

--> always use domain decomposition, never chunk decomposition