### PR TITLE
fix: define file open mode for z5py

### DIFF
--- a/organelle_morphology/source.py
+++ b/organelle_morphology/source.py
@@ -113,7 +113,7 @@ class DataSource:
         return f"DataSource of xml: {self.xml_path.stem}"
 
     def load_n5(self, n5: Path) -> dict[str, Timepoint]:
-        f = z5py.File(n5, "r")
+        f = z5py.File(n5, mode="r")
         timepoints = {}
         self.logger.debug(f"Start loading {n5}, metadata structure:")
 

--- a/tests/synthetic_data_generator.py
+++ b/tests/synthetic_data_generator.py
@@ -39,7 +39,7 @@ def generate_synthetic_dataset(
     cebra_dir = temp_dir
 
     filename = cebra_dir / "synth_data.n5"
-    f = z5py.File(filename, use_zarr_format=False)
+    f = z5py.File(filename, mode="a", use_zarr_format=False)
     group = f.create_group("setup0/timepoint0")
 
     downsampling_factors = ([1, 1, 1], [2, 2, 2], [4, 4, 4], [16, 16, 16])


### PR DESCRIPTION
with version 3.0, z5py switched the default opening mode.